### PR TITLE
Updated tournament, acss, reg data

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ Yunite.registrationData(['array of user Ids']).then((result => console.log(resul
 * [tournamentLeaderboards(tournamentId)](#tournamentleaderboardstournamentid) - Get leaderboard of tournament
 * [tournamentMatches(tournamentId)](#tournamentmatchestournamentid) - Get list of matches in tournament
 * [sessionLeaderboard(tournamentId, sessionId)](#sessionleaderboardtournamentid-sessionid) - Get leaderboard of single match
+* [acssStatistics(from, to)](#acssstatistics) - Get ACSS statistics from Yunite on a provided guild
+* [singleTournament()](#singletournamenttournamentid) - Get a single tournament
+* [listAllTournamentTeams(tournamentId)](#listalltournamentteamstournamentid) - Get all teams in a tournament
+* [epicRegistrationData(['array of user Ids'])](#epicRegistrationData) - Access registration data of a guild and know which Epic user is linked to which Discord user.
+* [addTeamToTournament(tournamentId, epicId, discordId)](#addteamtotournamenttournamentid-epicid-discordid-1) - Add team to a tournament (only one of Epic or Discord Id needed)
+* [disqualifyTeamFromTournament(teamId, tournamentId)](#disqualifyteamfromtournamentteamid-tournamentid) - Disqualifty a team from a tournament 
+* [updateTeam(teamId, tournamentId, players)](#updateteamteamid-tournamentid-players) - Update players in a team in a tournament
 
 ## registrationData(['array of user Ids'])
 Access registration data of a guild and know which Discord user is linked to which Epic user.
@@ -91,4 +98,55 @@ Yunite.tournamentMatches('bd4e8807-629f-4820-9207-13d899e76a67').then((result =>
 Get leaderboard of single match
 ```js
 Yunite.tournamentMatches('bd4e8807-629f-4820-9207-13d899e76a67', '56acd6f7627a4763b1b38c58f3fe5169').then((result => console.log(result)));
+```
+
+## acssStatistics(<from>, <to>)
+Get ACSS statistics from Yunite on a provided guild, optional from and to dates (UNIX-timestamp)
+```js
+Yunite.acssStatistics(1000, 2000).then((result => console.log(result)));
+```
+
+## singleTournament(tournamentId)
+Get single tournmanet by ID
+```js
+Yunite.singleTournament('bd4e8807-629f-4820-9207-13d899e76a67').then((result => console.log(result)));
+```
+
+## listAllTournamentTeams(tournamentId)
+Get all teams in a tournament
+```js
+Yunite.listAllTournamentTeams('bd4e8807-629f-4820-9207-13d899e76a67').then((result => console.log(result)));
+```
+
+## epicRegistrationData(['array of user Ids'])
+Access registration data of a guild and know which Epic user is linked to which Discord user
+```js
+Yunite.epicRegistrationData(['123456789123456789', '987654321987654321']).then((result => console.log(result)));
+```
+
+## addTeamToTournament(tournamentId, epicId, discordId)
+Add team to a tournament (only one of Epic or Discord Id needed)
+```js
+Yunite.addTeamToTournament('bd4e8807-629f-4820-9207-13d899e76a67', undefined, '987654321987654321').then((result => console.log(result)));
+```
+
+## disqualifyTeamFromTournament(teamId, tournamentId)
+Disqualifty a team from a tournament 
+```js
+Yunite.disqualifyTeamFromTournament('75757394-906f-461e-b33f-b51534d2563f', 'bd4e8807-629f-4820-9207-13d899e76a67').then((result => console.log(result)));
+```
+
+## updateTeam(teamId, tournamentId, players)
+Update players in a team in a tournament (only one of Epic or Discord Id needed)
+```js
+Yunite.updateTeam('75757394-906f-461e-b33f-b51534d2563f', 'bd4e8807-629f-4820-9207-13d899e76a67', {
+    player1: {
+        epicId: '1b17b72aaa36r579ebb47f832053cc30',
+        discordId: '987654321987654321'
+    },
+
+    player4: {
+        epicId: '1b17b72aaa36r579ebb47f832053cc30'
+    }
+}).then((result => console.log(result)));
 ```

--- a/src/functions/acssStatistics.js
+++ b/src/functions/acssStatistics.js
@@ -1,8 +1,12 @@
 const fetch = require('node-fetch');
 const config = require('../config.js');
 
-module.exports = async function (authorization, guildId) {
-    return fetch(`https://${config.domain}/guild/${guildId}/acss/stats`, {
+module.exports = async function (authorization, guildId, from, to) {
+    let url = `https://${config.domain}/guild/${guildId}/acss/stats?`;
+    if (from) { url += `from=${from}&`; };
+    if (to) { url += `to=${to}`; };
+
+    return fetch(url, {
         method: 'get',
         headers: {
             'Content-Type': 'application/json',

--- a/src/functions/acssStatistics.js
+++ b/src/functions/acssStatistics.js
@@ -1,0 +1,16 @@
+const fetch = require('node-fetch');
+const config = require('../config.js');
+
+module.exports = async function (authorization, guildId) {
+    return fetch(`https://${config.domain}/guild/${guildId}/acss/stats`, {
+        method: 'get',
+        headers: {
+            'Content-Type': 'application/json',
+            'Y-Api-Token': authorization
+        },
+    }).then(res => res.json()).then(async json => {
+        return await json;
+    }).catch(async error => {
+        throw new Error(error);
+    });
+};

--- a/src/functions/addTeamToTournament.js
+++ b/src/functions/addTeamToTournament.js
@@ -1,0 +1,22 @@
+const fetch = require('node-fetch');
+const config = require('../config.js');
+
+module.exports = async function (tournamentId, authorization, guildId, epicId, discordId) {
+    let data = { "id": null, "players": []};
+
+    if (epicId) { data.players.push({ "epicId": epicId });}
+    if (discordId) { data.players.push({ "discordId": discordId }); };
+
+    return fetch(`https://yunite.xyz/api/v3/guild/${guildId}/tournaments/${tournamentId}/teams`, {
+        method: 'post',
+        body: JSON.stringify(data),
+        headers: {
+            'Content-Type': 'application/json',
+            'Y-Api-Token': authorization
+        },
+    }).then(res => res.json()).then(async json => {
+        return await json;
+    }).catch(async error => {
+        throw new Error(error);
+    });
+};

--- a/src/functions/disqualifyTeamFromTournament.js
+++ b/src/functions/disqualifyTeamFromTournament.js
@@ -1,0 +1,19 @@
+const fetch = require('node-fetch');
+const config = require('../config.js');
+
+module.exports = async function (teamId, tournamentId, authorization, guildId) {
+    let data = { "id": teamId, "players": null, "disqualified": true};
+
+    return fetch(`https://yunite.xyz/api/v3/guild/${guildId}/tournaments/${tournamentId}/teams`, {
+        method: 'post',
+        body: JSON.stringify(data),
+        headers: {
+            'Content-Type': 'application/json',
+            'Y-Api-Token': authorization
+        },
+    }).then(res => res.json()).then(async json => {
+        return await json;
+    }).catch(async error => {
+        throw new Error(error);
+    });
+};

--- a/src/functions/epicRegistrationData.js
+++ b/src/functions/epicRegistrationData.js
@@ -1,0 +1,18 @@
+const fetch = require('node-fetch');
+const config = require('../config.js');
+
+module.exports = async function (id, authorization, guildId, endpoint) {
+    let data = { "type": 'EPIC', 'userIds': id };
+    return fetch(`https://${config.domain}${endpoint.replace(':guildId', `${guildId}`)}`, {
+        method: 'post',
+        body: JSON.stringify(data),
+        headers: {
+            'Content-Type': 'application/json',
+            'Y-Api-Token': authorization
+        },
+    }).then(res => res.json()).then(async json => {
+        return await json;
+    }).catch(async error => {
+        throw new Error(error);
+    });
+};

--- a/src/functions/index.js
+++ b/src/functions/index.js
@@ -12,5 +12,6 @@ module.exports = {
     acssStatistics: require('./acssStatistics.js'),
     singleTournament:  require('./singleTournament.js'),
     listAllTournamentTeams: require('./listAllTournamentTeams.js'),
-    epicRegistrationData: require('./epicRegistrationData')
+    epicRegistrationData: require('./epicRegistrationData'),
+    addTeamToTournament: require('./addTeamToTournament')
 };

--- a/src/functions/index.js
+++ b/src/functions/index.js
@@ -8,5 +8,7 @@ module.exports = {
     listTournaments: require('./listTournaments.js'),
     tournamentLeaderboards: require('./tournamentLeaderboards.js'),
     tournamentMatches: require('./tournamentMatches.js'),
-    sessionLeaderboard: require('./sessionLeaderboard.js')
+    sessionLeaderboard: require('./sessionLeaderboard.js'),
+    acssStatistics: require('./acssStatistics'),
+    singleTournament:  require('./singleTournament.js')
 };

--- a/src/functions/index.js
+++ b/src/functions/index.js
@@ -13,5 +13,6 @@ module.exports = {
     singleTournament:  require('./singleTournament.js'),
     listAllTournamentTeams: require('./listAllTournamentTeams.js'),
     epicRegistrationData: require('./epicRegistrationData'),
-    addTeamToTournament: require('./addTeamToTournament')
+    addTeamToTournament: require('./addTeamToTournament'),
+    disqualifyTeamFromTournament: require('./disqualifyTeamFromTournament')
 };

--- a/src/functions/index.js
+++ b/src/functions/index.js
@@ -14,5 +14,6 @@ module.exports = {
     listAllTournamentTeams: require('./listAllTournamentTeams.js'),
     epicRegistrationData: require('./epicRegistrationData'),
     addTeamToTournament: require('./addTeamToTournament'),
-    disqualifyTeamFromTournament: require('./disqualifyTeamFromTournament')
+    disqualifyTeamFromTournament: require('./disqualifyTeamFromTournament'),
+    updateTeam: require('./updateTeam')
 };

--- a/src/functions/index.js
+++ b/src/functions/index.js
@@ -11,5 +11,6 @@ module.exports = {
     sessionLeaderboard: require('./sessionLeaderboard.js'),
     acssStatistics: require('./acssStatistics.js'),
     singleTournament:  require('./singleTournament.js'),
-    listAllTournamentTeams: require('./listAllTournamentTeams.js')
+    listAllTournamentTeams: require('./listAllTournamentTeams.js'),
+    epicRegistrationData: require('./epicRegistrationData')
 };

--- a/src/functions/index.js
+++ b/src/functions/index.js
@@ -9,6 +9,7 @@ module.exports = {
     tournamentLeaderboards: require('./tournamentLeaderboards.js'),
     tournamentMatches: require('./tournamentMatches.js'),
     sessionLeaderboard: require('./sessionLeaderboard.js'),
-    acssStatistics: require('./acssStatistics'),
-    singleTournament:  require('./singleTournament.js')
+    acssStatistics: require('./acssStatistics.js'),
+    singleTournament:  require('./singleTournament.js'),
+    listAllTournamentTeams: require('./listAllTournamentTeams.js')
 };

--- a/src/functions/listAllTournamentTeams.js
+++ b/src/functions/listAllTournamentTeams.js
@@ -1,0 +1,16 @@
+const fetch = require('node-fetch');
+const config = require('../config.js');
+
+module.exports = async function (authorization, guildId, tournamentId) {
+    return fetch(`https://${config.domain}/guild/${guildId}/tournaments/${tournamentId}/teams`, {
+        method: 'get',
+        headers: {
+            'Content-Type': 'application/json',
+            'Y-Api-Token': authorization
+        },
+    }).then(res => res.json()).then(async json => {
+        return await json;
+    }).catch(async error => {
+        throw new Error(error);
+    });
+};

--- a/src/functions/singleTournament.js
+++ b/src/functions/singleTournament.js
@@ -1,0 +1,16 @@
+const fetch = require('node-fetch');
+const config = require('../config.js');
+
+module.exports = async function (authorization, guildId, tournamentId) {
+    return fetch(`https://${config.domain}/guild/${guildId}/tournaments/${tournamentId}`, {
+        method: 'get',
+        headers: {
+            'Content-Type': 'application/json',
+            'Y-Api-Token': authorization
+        },
+    }).then(res => res.json()).then(async json => {
+        return await json;
+    }).catch(async error => {
+        throw new Error(error);
+    });
+};

--- a/src/functions/updateTeam.js
+++ b/src/functions/updateTeam.js
@@ -1,0 +1,26 @@
+const fetch = require('node-fetch');
+const config = require('../config.js');
+
+module.exports = async function (teamId, tournamentId, authorization, guildId, playersArray) {
+    let data = { "id": teamId, "players": []};
+
+    if (playersArray.player1) { data.players.push(playersArray.player1);};
+    if (playersArray.player2) { data.players.push(playersArray.player2);};
+    if (playersArray.player3) { data.players.push(playersArray.player3);};
+    if (playersArray.player4) { data.players.push(playersArray.player4);};
+
+    console.log(JSON.stringify(data));
+
+    return fetch(`https://yunite.xyz/api/v3/guild/${guildId}/tournaments/${tournamentId}/teams`, {
+        method: 'post',
+        body: JSON.stringify(data),
+        headers: {
+            'Content-Type': 'application/json',
+            'Y-Api-Token': authorization
+        },
+    }).then(res => res.json()).then(async json => {
+        return await json;
+    }).catch(async error => {
+        throw new Error(error);
+    });
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const { registrationData, blockUser, blockEpic, unblockUser, unblockEpic, addPlayerToQueue, listTournaments, tournamentLeaderboards, tournamentMatches, sessionLeaderboard, acssStatistics, singleTournament, listAllTournamentTeams, epicRegistrationData } = require('./functions');
+const { registrationData, blockUser, blockEpic, unblockUser, unblockEpic, addPlayerToQueue, listTournaments, tournamentLeaderboards, tournamentMatches, sessionLeaderboard, acssStatistics, singleTournament, listAllTournamentTeams, epicRegistrationData, addTeamToTournament } = require('./functions');
 const config = require('./config');
 
 /**
@@ -118,7 +118,7 @@ class YuniteAPI {
      * @param {Number} from The UNIX-timestamp of the from date 
      * @param {Number} to The UNIX-timestamp of the to date
      */
-    async acssStatistics(from, to) {
+    async acssStatistics(from = this.from, to = this.to) {
         return acssStatistics(this._token, this._guildId, from, to);
     }
 
@@ -148,6 +148,18 @@ class YuniteAPI {
         if (!Array.isArray(id)) throw new TypeError('User Ids is an array');
         if (id.length === 0) throw new TypeError('No User Ids');
         return epicRegistrationData(id, this._token, this._guildId, config.endpoints.registration);
+    }
+
+    /**
+     * Add team to a tournament
+     * @param {String} epicId User Epic ID of the player you're adding to the tournament (only either Epic or Discord Id needed)
+     * @param {String} discordId User Discord ID of the player you're adding to the tournament (only either Epic or Discord Id needed)
+     * @param {String} tournamentId Tournament ID 
+     */
+    async addTeamToTournament(tournamentId = this.tournamentId, epicId = this.epicId, discordId = this.discordId) {
+        if (!tournamentId) throw new TypeError('No Tournament ID Provided');
+        if (!epicId && !discordId) throw new TypeError('At least 1 of Epic or Discord Id needed');
+        return addTeamToTournament(tournamentId, this._token, this._guildId, epicId, discordId);
     }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const { registrationData, blockUser, blockEpic, unblockUser, unblockEpic, addPlayerToQueue, listTournaments, tournamentLeaderboards, tournamentMatches, sessionLeaderboard, acssStatistics, singleTournament, listAllTournamentTeams } = require('./functions');
+const { registrationData, blockUser, blockEpic, unblockUser, unblockEpic, addPlayerToQueue, listTournaments, tournamentLeaderboards, tournamentMatches, sessionLeaderboard, acssStatistics, singleTournament, listAllTournamentTeams, epicRegistrationData } = require('./functions');
 const config = require('./config');
 
 /**
@@ -136,6 +136,16 @@ class YuniteAPI {
      async listAllTournamentTeams(tournamentId = this.tournamentId) {
         if (!tournamentId) throw new TypeError('No Tournament ID Provided');
         return listAllTournamentTeams(this._token, this._guildId, tournamentId);
+    }
+
+    /**
+     * Get Epic registration data
+     * @param {Array} id The Epic users id who you're getting registration data of
+     */
+    async epicRegistrationData(id = this.id) {
+        if (!Array.isArray(id)) throw new TypeError('User Ids is an array');
+        if (id.length === 0) throw new TypeError('No User Ids');
+        return epicRegistrationData(id, this._token, this._guildId, config.endpoints.registration);
     }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const { registrationData, blockUser, blockEpic, unblockUser, unblockEpic, addPlayerToQueue, listTournaments, tournamentLeaderboards, tournamentMatches, sessionLeaderboard } = require('./functions');
+const { registrationData, blockUser, blockEpic, unblockUser, unblockEpic, addPlayerToQueue, listTournaments, tournamentLeaderboards, tournamentMatches, sessionLeaderboard, acssStatistics, singleTournament } = require('./functions');
 const config = require('./config');
 
 /**
@@ -111,6 +111,21 @@ class YuniteAPI {
         if (!tournamentId) throw new TypeError('No Tournament ID Provided');
         if (!sessionId) throw new TypeError('No Session ID Provided');
         return sessionLeaderboard(tournamentId, sessionId, this._token, this._guildId, config.endpoints.single_tournament_leaderboard);
+    }
+
+    /**
+     * Get ACSS statistics
+     */
+    async acssStatistics() {
+        return acssStatistics(this._token, this._guildId);
+    }
+
+    /**
+     * Get single tournament 
+     */
+    async singleTournament(tournamentId = this.tournamentId) {
+        if (!tournamentId) throw new TypeError('No Tournament ID Provided');
+        return singleTournament(this._token, this._guildId, tournamentId);
     }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const { registrationData, blockUser, blockEpic, unblockUser, unblockEpic, addPlayerToQueue, listTournaments, tournamentLeaderboards, tournamentMatches, sessionLeaderboard, acssStatistics, singleTournament } = require('./functions');
+const { registrationData, blockUser, blockEpic, unblockUser, unblockEpic, addPlayerToQueue, listTournaments, tournamentLeaderboards, tournamentMatches, sessionLeaderboard, acssStatistics, singleTournament, listAllTournamentTeams } = require('./functions');
 const config = require('./config');
 
 /**
@@ -122,10 +122,20 @@ class YuniteAPI {
 
     /**
      * Get single tournament 
+     * @param {String} tournamentId Tournament ID
      */
     async singleTournament(tournamentId = this.tournamentId) {
         if (!tournamentId) throw new TypeError('No Tournament ID Provided');
         return singleTournament(this._token, this._guildId, tournamentId);
+    }
+
+    /**
+     * Get all teams in a tournament
+     * @param {String} tournamentId Tournament ID
+     */
+     async listAllTournamentTeams(tournamentId = this.tournamentId) {
+        if (!tournamentId) throw new TypeError('No Tournament ID Provided');
+        return listAllTournamentTeams(this._token, this._guildId, tournamentId);
     }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const { registrationData, blockUser, blockEpic, unblockUser, unblockEpic, addPlayerToQueue, listTournaments, tournamentLeaderboards, tournamentMatches, sessionLeaderboard, acssStatistics, singleTournament, listAllTournamentTeams, epicRegistrationData, addTeamToTournament } = require('./functions');
+const { registrationData, blockUser, blockEpic, unblockUser, unblockEpic, addPlayerToQueue, listTournaments, tournamentLeaderboards, tournamentMatches, sessionLeaderboard, acssStatistics, singleTournament, listAllTournamentTeams, epicRegistrationData, addTeamToTournament, disqualifyTeamFromTournament } = require('./functions');
 const config = require('./config');
 
 /**
@@ -160,6 +160,17 @@ class YuniteAPI {
         if (!tournamentId) throw new TypeError('No Tournament ID Provided');
         if (!epicId && !discordId) throw new TypeError('At least 1 of Epic or Discord Id needed');
         return addTeamToTournament(tournamentId, this._token, this._guildId, epicId, discordId);
+    }
+
+    /**
+     * 
+     * @param {String} teamId Team ID 
+     * @param {String} tournamentId Tournament ID 
+     */
+    async disqualifyTeamFromTournament(teamId = this.teamId, tournamentId = this.tournamentId) {
+        if (!teamId) throw new TypeError('No Tournament ID Provided');
+        if (!tournamentId) throw new TypeError('No Team ID Provided');
+        return disqualifyTeamFromTournament(teamId, tournamentId, this._token, this._guildId);
     }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -115,9 +115,11 @@ class YuniteAPI {
 
     /**
      * Get ACSS statistics
+     * @param {Number} from The UNIX-timestamp of the from date 
+     * @param {Number} to The UNIX-timestamp of the to date
      */
-    async acssStatistics() {
-        return acssStatistics(this._token, this._guildId);
+    async acssStatistics(from, to) {
+        return acssStatistics(this._token, this._guildId, from, to);
     }
 
     /**

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const { registrationData, blockUser, blockEpic, unblockUser, unblockEpic, addPlayerToQueue, listTournaments, tournamentLeaderboards, tournamentMatches, sessionLeaderboard, acssStatistics, singleTournament, listAllTournamentTeams, epicRegistrationData, addTeamToTournament, disqualifyTeamFromTournament } = require('./functions');
+const { registrationData, blockUser, blockEpic, unblockUser, unblockEpic, addPlayerToQueue, listTournaments, tournamentLeaderboards, tournamentMatches, sessionLeaderboard, acssStatistics, singleTournament, listAllTournamentTeams, epicRegistrationData, addTeamToTournament, disqualifyTeamFromTournament, updateTeam } = require('./functions');
 const config = require('./config');
 
 /**
@@ -171,6 +171,20 @@ class YuniteAPI {
         if (!teamId) throw new TypeError('No Tournament ID Provided');
         if (!tournamentId) throw new TypeError('No Team ID Provided');
         return disqualifyTeamFromTournament(teamId, tournamentId, this._token, this._guildId);
+    }
+
+    /**
+     * 
+     * @param {String} teamId Team ID 
+     * @param {String} tournamentId Team ID 
+     * @param {Object} players Epic and/or Discord ID of each of the players
+     */
+    async updateTeam(teamId = this.teamId, tournamentId = this.tournamentId, players = this.players) {
+        if (!teamId) throw new TypeError('No Tournament ID Provided');
+        if (!tournamentId) throw new TypeError('No Team ID Provided');
+        if (!players) throw new TypeError('No Players Provided');
+        if (!players.player1 && !players.player2 && !players.player3 && !players.player4) throw new TypeError('No Players Found in Array');
+        return updateTeam(teamId, tournamentId, this._token, this._guildId, players);
     }
 }
 


### PR DESCRIPTION
New methods in [tournaments](https://yunite.xyz/docs/developers/tournaments): 

```
singleTournament - Get a single tournament's data
listAllTournamentTeams - List all teams and team members of a tournament
addTeamToTournament - Add team to a tournament by Discord and/or Epic ID
disqualifyTeamFromTournament - Disqualifty a team from a tournament
updateTeams - Update a teams members
```

New methods in [acss](https://yunite.xyz/docs/developers/acss): 

```
acssStatistics - Get acss statistics with optional to and from timestamps
```

New methods in [registration](https://yunite.xyz/docs/developers/registrationdata): 

```
epicRegistrationData - Get registration data and access which Epic is linked to which Discord 
```